### PR TITLE
Updated resvg version, error checking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quad-svg"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "render svg to macroquad::texture::Texture2D using resvg"
 license = "MIT/Apache-2.0"
@@ -10,6 +10,5 @@ repository = "https://github.com/macnelly/quad-svg/"
 
 [dependencies]
 macroquad = "0.3.0"
-resvg = "0.28.0"
+resvg = "0.33.0"
 rand = "0.8.5"
-getrandom = { version = "0.2", features = ["js"] }

--- a/examples/ferris.rs
+++ b/examples/ferris.rs
@@ -51,7 +51,7 @@ async fn main() {
       d=\"m 59.874768,44.889364 c -0.180529,2.490275 -4.437976,3.807787 -5.776051,0.395645 z\"
       id=\"path27676\" />
  </g></svg>";
-    let texture = quad_svg::svg_to_texture(&svg_data);
+    let texture = quad_svg::svg_to_texture(&svg_data, &quad_svg::Transform::default()).unwrap();
     let mut positions: Vec<Position> = vec![];
     for _i in 0..50 {
         positions.push(Position {

--- a/examples/star.rs
+++ b/examples/star.rs
@@ -42,7 +42,10 @@ async fn main() {
             y=\"36.092587\">Text</tspan></text>
      </g>
  </svg>";
-    let texture = quad_svg::svg_to_texture(&svg_data);
+    let texture = match quad_svg::svg_to_texture(&svg_data, &quad_svg::Transform::default()) {
+        Ok(texture) => texture,
+        Err(err) => panic!("{}", err)
+    };
     let mut positions: Vec<Position> = vec![];
     for _i in 0..100 {
         positions.push(Position {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,37 +1,69 @@
 use macroquad::{prelude::ImageFormat, texture::Texture2D};
-use resvg::usvg_text_layout::{fontdb, TreeTextToPath};
+use resvg::usvg::{TreeParsing, TreeTextToPath};
+
+pub use resvg::tiny_skia::Transform;
 
 /*
     TODO: include font file in package to not rely on system fonts
 */
 
-/*
-    rasterize svg to png image
-*/
-pub fn svg_to_png(svg_str: &str) -> Vec<u8> {
-    let opt = resvg::usvg::Options::default();
-    let mut tree = resvg::usvg::Tree::from_str(svg_str, &opt).unwrap();
-    let mut fontdb = fontdb::Database::new();
-    fontdb.load_system_fonts();
-    tree.convert_text(&fontdb, opt.keep_named_groups);
-    let pixmap_size = tree.size.to_screen_size();
-    let mut pixmap =
-        resvg::tiny_skia::Pixmap::new(pixmap_size.width(), pixmap_size.height()).unwrap();
+#[derive(Debug)]
+pub enum SVGParseError {
+    SVGSourceParse,
+    NoFonts,
+    InvalidTransform,
+    PNGEncoding,
+}
 
-    resvg::render(
-        &tree,
-        resvg::usvg::FitTo::Original,
-        resvg::tiny_skia::Transform::default(),
-        pixmap.as_mut(),
-    )
-    .unwrap();
-    pixmap.encode_png().unwrap()
+impl std::error::Error for SVGParseError {}
+impl std::fmt::Display for SVGParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SVGParseError::SVGSourceParse => write!(f, "Invalid SVG source"),
+            SVGParseError::NoFonts => write!(f, "No system fonts found"),
+            SVGParseError::InvalidTransform => write!(f, "Invalid texture transform"),
+            SVGParseError::PNGEncoding => write!(f, "Failed to encode PNG"),
+        }
+    }
 }
 
 /*
     rasterize svg and create Texture2D
 */
-pub fn svg_to_texture(svg_str: &str) -> Texture2D {
-    let png_data = svg_to_png(&svg_str);
-    Texture2D::from_file_with_format(&png_data, Some(ImageFormat::Png))
+pub fn svg_to_texture(svg_source: &str, transform: &Transform) -> Result<Texture2D, SVGParseError> {
+    let png_data = svg_to_png(svg_source, transform)?;
+    Ok(Texture2D::from_file_with_format(
+        &png_data,
+        Some(ImageFormat::Png),
+    ))
+}
+
+/*
+    rasterize svg to png image
+*/
+fn svg_to_png(svg_source: &str, transform: &Transform) -> Result<Vec<u8>, SVGParseError> {
+    let mut tree = resvg::usvg::Tree::from_str(svg_source, &resvg::usvg::Options::default())
+        .map_err(|_| SVGParseError::SVGSourceParse)?;
+
+    if tree.has_text_nodes() {
+        let mut fontdb = resvg::usvg::fontdb::Database::new();
+    
+        if fontdb.is_empty() {
+            return Err(SVGParseError::NoFonts);
+        }
+    
+        fontdb.load_system_fonts();
+        tree.convert_text(&fontdb);
+    }
+
+    let mut pixmap = resvg::tiny_skia::Pixmap::new(
+        (transform.sx * tree.size.width() as f32) as u32,
+        (transform.sy * tree.size.height() as f32) as u32,
+    )
+    .ok_or(SVGParseError::InvalidTransform)?;
+
+    let tree = resvg::Tree::from_usvg(&tree);
+    tree.render(*transform, &mut pixmap.as_mut());
+
+    pixmap.encode_png().map_err(|_| SVGParseError::PNGEncoding)
 }


### PR DESCRIPTION
- Updated `resvg` from `0.28.0` to `0.33.0`
- Exposed `resvg::tiny_skia::Transform` to crate users to allow transforming the SVG before it is baked into a  `Texture2D`
- Improved error handling with `Result`
- Removed `pub` modifier on `svg_to_png` since this library is only for `macroquad`
- Removed unused `getrandom` crate in `Cargo.toml`

**NOTE**: Did not fix the font issue, still crashes when `Caladea` is not installed on running the `star` example

Please check that I did the error handling correctly, I haven't done it manually before. I usually rely on `anyhow`.

I was just using this library for a simple chess clone and I needed to scale up the pieces depending on the window size so I decided to add transforms.